### PR TITLE
Fix type returned by BranchDB

### DIFF
--- a/testsvc/src/main/java/score/BranchDB.java
+++ b/testsvc/src/main/java/score/BranchDB.java
@@ -17,5 +17,5 @@
 package score;
 
 public interface BranchDB<K, V> {
-    Object at(K key);
+    V at(K key);
 }


### PR DESCRIPTION
`BranchDB.at` always returns a V value