### PR TITLE
Remove the unused "tokenId" warning in IRC3BasicTest

### DIFF
--- a/irc3-token/src/test/java/com/iconloop/score/example/IRC3BasicTest.java
+++ b/irc3-token/src/test/java/com/iconloop/score/example/IRC3BasicTest.java
@@ -73,7 +73,7 @@ public class IRC3BasicTest extends TestBase {
 
     @Test
     void balanceOf() {
-        var tokenId = mintToken();
+        mintToken();
         assertEquals(1, tokenScore.call("balanceOf", owner.getAddress()));
     }
 


### PR DESCRIPTION
"tokenId" is not used in the balanceOf test.

![https://i.imgur.com/rerUC2R.png](https://i.imgur.com/rerUC2R.png)